### PR TITLE
ipv4-l3-protocol fix to avoid removal of SocketIPTosTag

### DIFF
--- a/src/internet/model/ipv4-l3-protocol.cc
+++ b/src/internet/model/ipv4-l3-protocol.cc
@@ -770,7 +770,7 @@ Ipv4L3Protocol::Send (Ptr<Packet> packet,
 
   uint8_t tos = 0;
   SocketIpTosTag ipTosTag;
-  bool ipTosTagFound = packet->RemovePacketTag (ipTosTag);
+  bool ipTosTagFound = packet->PeekPacketTag (ipTosTag);
   if (ipTosTagFound)
     {
       tos = ipTosTag.GetTos ();


### PR DESCRIPTION
SocketIpTosTag is used to classify the priority of packets in PfifoHomaQueueDisc.